### PR TITLE
pass env to specify node functionalities

### DIFF
--- a/docker/start
+++ b/docker/start
@@ -91,6 +91,7 @@ run_graph_node() {
 start_query_node() {
     # Query nodes are never the block ingestor
     export DISABLE_BLOCK_INGESTOR=true
+    export NODE_FUNCTIONALITIES=query-only
     run_graph_node
 }
 

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -487,6 +487,7 @@ mod test {
             ethereum_ipc: vec![],
             unsafe_config: false,
             bus_url: Some("not needed".to_string()),
+            functionalities: crate::config::NodeFunctionalities::Combined,
         };
 
         let config = Config::load(&logger, &opt).expect("can create config");

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -219,7 +219,7 @@ impl Config {
             .expect("a validated config has a primary store")
     }
 
-    pub fn query_only(&self, node: &NodeId) -> bool {
+    pub fn query_only(&self, _node: &NodeId) -> bool {
         match self.functionalities {
             NodeFunctionalities::QueryOnly => true,
             _ => false,

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -82,7 +82,7 @@ pub struct Config {
     pub stores: BTreeMap<String, Shard>,
     pub chains: ChainSection,
     pub deployment: Deployment,
-    pub functionalities: NodeFunctionalities,
+    pub functionalities: Option<NodeFunctionalities>,
 }
 
 fn validate_name(s: &str) -> Result<()> {
@@ -199,7 +199,7 @@ impl Config {
             stores,
             chains,
             deployment,
-            functionalities,
+            functionalities: Some(functionalities),
         })
     }
 
@@ -221,9 +221,14 @@ impl Config {
 
     pub fn query_only(&self, _node: &NodeId) -> bool {
         match self.functionalities {
-            NodeFunctionalities::QueryOnly => true,
+            Some(NodeFunctionalities::QueryOnly) => true,
             _ => false,
         }
+        /*
+        FIXME: we gonna have to deal with this later
+        once we start using `config.toml` for instance's configuration
+        */
+
         // self.general
         //     .as_ref()
         //     .map(|g| match g.query.find(node.as_str()) {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -142,6 +142,13 @@ async fn main() {
         .expect("Node ID must be between 1 and 63 characters in length");
     let query_only = config.query_only(&node_id);
 
+    warn!(
+        logger, "GRAPH_NODE_FUNCTIONALITIES";
+        "query-only" => query_only,
+        "disable-block-ingestor" => opt.disable_block_ingestor,
+        "functionalities" => opt.functionalities,
+    );
+
     // Obtain subgraph related command-line arguments
     let subgraph = opt.subgraph.clone();
 

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -231,6 +231,15 @@ pub struct Opt {
         help = "Bus service to send event from graph-node to"
     )]
     pub bus_url: Option<String>,
+
+    #[clap(
+        long,
+        value_name = "FUNCTIONALTIES",
+        default_value = "combined",
+        env = "NODE_FUNCTIONALITIES",
+        help = "Node dedicated functionalities"
+    )]
+    pub functionalities: String,
 }
 
 impl From<Opt> for config::Opt {
@@ -248,6 +257,7 @@ impl From<Opt> for config::Opt {
             ethereum_ipc,
             unsafe_config,
             bus_url,
+            functionalities,
             ..
         } = opt;
 
@@ -264,6 +274,11 @@ impl From<Opt> for config::Opt {
             ethereum_ipc,
             unsafe_config,
             bus_url,
+            functionalities: match &functionalities.as_str() {
+                &"query-only" => config::NodeFunctionalities::QueryOnly,
+                &"indexer" => config::NodeFunctionalities::Indexer,
+                _ => config::NodeFunctionalities::Combined,
+            },
         }
     }
 }


### PR DESCRIPTION
pass env to configure node functionalities:

GraphNode does not allow toggling its functionalities (indexing/querying only) through envars. This PR fix that and allow user to specify which functionalities(index-only/query-only or both) he wants the node to have