### PR TITLE
Add functionality toggles (#6) + Add subgraph-name to metrics (#7, #8)

### DIFF
--- a/.github/workflows/kyber-ci.yml
+++ b/.github/workflows/kyber-ci.yml
@@ -67,7 +67,7 @@ jobs:
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld -D warnings"
         with:
           command: test
-          args: --verbose --workspace --exclude graph-tests -- --nocapture
+          args: --workspace --exclude graph-tests -- --nocapture
 
   # runner-tests:
   #   name: Subgraph Runner integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ lcov.info
 
 /tests/**/bin
 /tests/**/truffle_output
+.cargo/
 
 # ignore config file
 key.json

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,28 @@
+[general]
+query = "query_.*"
+
+[chains]
+ingestor = "indexer_.*"
+[chains.optimism]
+shard = "primary"
+provider = [
+  { label = "optimism", url = "https://mainnet.optimism.io", features = ["archive"] },
+]
+
+[store]
+[store.primary]
+connection = "postgresql://graph-node:let-me-in@localhost:5432/graph-node"
+pool_size = 20
+
+[deployment]
+[[deployment.rule]]
+match = { name = "shard_01/.*" }
+shard = "primary"
+indexers = [ "indexer_01" ]
+[[deployment.rule]]
+match = { name = "shard_02/.*" }
+shard = "primary"
+indexers = [ "indexer_02" ]
+[[deployment.rule]]
+shards = ["primary"]
+indexers = [ "default" ]

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -334,7 +334,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         // ownership of the manifest and host builder into the new instance
         let stopwatch_metrics = StopwatchMetrics::new(
             logger.clone(),
-            deployment.readable_name(),
+            &deployment,
             "process",
             self.metrics_registry.clone(),
         );
@@ -354,13 +354,13 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         let subgraph_metrics = Arc::new(SubgraphInstanceMetrics::new(
             registry.cheap_clone(),
-            &deployment.readable_name(),
+            &deployment,
             stopwatch_metrics.clone(),
         ));
 
         let block_stream_metrics = Arc::new(BlockStreamMetrics::new(
             registry.cheap_clone(),
-            deployment.readable_name(),
+            &deployment,
             manifest.network_name(),
             store.shard().to_string(),
             stopwatch_metrics,

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -334,7 +334,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         // ownership of the manifest and host builder into the new instance
         let stopwatch_metrics = StopwatchMetrics::new(
             logger.clone(),
-            deployment.hash.clone(),
+            deployment.readable_name(),
             "process",
             self.metrics_registry.clone(),
         );
@@ -348,19 +348,19 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         let host_metrics = Arc::new(HostMetrics::new(
             registry.cheap_clone(),
-            deployment.hash.as_str(),
+            &deployment.readable_name(),
             stopwatch_metrics.clone(),
         ));
 
         let subgraph_metrics = Arc::new(SubgraphInstanceMetrics::new(
             registry.cheap_clone(),
-            deployment.hash.as_str(),
+            &deployment.readable_name(),
             stopwatch_metrics.clone(),
         ));
 
         let block_stream_metrics = Arc::new(BlockStreamMetrics::new(
             registry.cheap_clone(),
-            &deployment.hash,
+            deployment.readable_name(),
             manifest.network_name(),
             store.shard().to_string(),
             stopwatch_metrics,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -273,9 +273,11 @@ where
         // We don't have a location for the subgraph yet; that will be
         // assigned when we deploy for real. For logging purposes, make up a
         // fake locator
-        let logger = self
-            .logger_factory
-            .subgraph_logger(&DeploymentLocator::new(DeploymentId(0), hash.clone()));
+        let logger = self.logger_factory.subgraph_logger(&DeploymentLocator::new(
+            DeploymentId(0),
+            hash.clone(),
+            Some(name.clone().to_string()),
+        ));
 
         let raw: serde_yaml::Mapping = {
             let file_bytes = self

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - '5001:5001'
     volumes:
       - ./data/ipfs:/data/ipfs
+
   postgres:
     image: postgres
     ports:
@@ -47,6 +48,22 @@ services:
       POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+
+  pg-test:
+    image: postgres
+    ports:
+      - '5432:5432'
+    command:
+      [
+        "postgres",
+        "-cshared_preload_libraries=pg_stat_statements"
+      ]
+    environment:
+      POSTGRES_USER: graph
+      POSTGRES_PASSWORD: graph
+      POSTGRES_DB: graph-test
+      PGDATA: "/var/lib/postgresql/data"
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
 
   prometheus:
     image: prom/prometheus:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,26 +1,26 @@
 version: '3'
 services:
-  graph-node:
-    image: graphprotocol/graph-node
-    ports:
-      - '8000:8000'
-      - '8001:8001'
-      - '8020:8020'
-      - '8030:8030'
-      - '8040:8040'
-    depends_on:
-      - ipfs
-      - postgres
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    environment:
-      postgres_host: postgres
-      postgres_user: graph-node
-      postgres_pass: let-me-in
-      postgres_db: graph-node
-      ipfs: 'ipfs:5001'
-      ethereum: 'mainnet:http://host.docker.internal:8545'
-      GRAPH_LOG: info
+  # graph-node:
+  #   image: graphprotocol/graph-node
+  #   ports:
+  #     - '8000:8000'
+  #     - '8001:8001'
+  #     - '8020:8020'
+  #     - '8030:8030'
+  #     - '8040:8040'
+  #   depends_on:
+  #     - ipfs
+  #     - postgres
+  #   extra_hosts:
+  #     - host.docker.internal:host-gateway
+  #   environment:
+  #     postgres_host: postgres
+  #     postgres_user: graph-node
+  #     postgres_pass: let-me-in
+  #     postgres_db: graph-node
+  #     ipfs: 'ipfs:5001'
+  #     ethereum: 'mainnet:http://host.docker.internal:8545'
+  #     GRAPH_LOG: info
   ipfs:
     image: ipfs/go-ipfs:v0.10.0
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,3 +47,29 @@ services:
       POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=200h'
+      - '--web.enable-lifecycle'
+    ports:
+      - 9090:9090
+
+  grafana:
+    image: grafana/grafana-enterprise:latest
+    container_name: grafana
+    ports:
+      - 3000:3000
+    command:
+      - '--config=/etc/grafana/custom.ini'
+    volumes:
+      - ./grafana:/etc/grafana/provisioning
+      - ./grafana/custom.ini:/etc/grafana/custom.ini

--- a/docker/grafana/custom.ini
+++ b/docker/grafana/custom.ini
@@ -1,0 +1,3 @@
+[auth.anonymous]
+enabled = true
+org_role = Admin

--- a/docker/grafana/dashboards/graph-node-detail.json
+++ b/docker/grafana/dashboards/graph-node-detail.json
@@ -688,11 +688,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "QmUGTBpna7c9dwMeWwSfazu2bVV9UDGZSbdHxha3CCuzk4",
-          "value": "QmUGTBpna7c9dwMeWwSfazu2bVV9UDGZSbdHxha3CCuzk4"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
@@ -706,6 +702,29 @@
         "options": [],
         "query": {
           "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values({deployment=\"$deployment\"}, name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "subgraph",
+        "multi": false,
+        "name": "subgraph",
+        "options": [],
+        "query": {
+          "query": "label_values({deployment=\"$deployment\"}, name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/docker/grafana/dashboards/graph-node-detail.json
+++ b/docker/grafana/dashboards/graph-node-detail.json
@@ -1,0 +1,729 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "max(deployment_head{deployment=\"$deployment\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Deployment Head",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "max(ethereum_chain_head_number)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Chain Head",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "max(ethereum_chain_head_number - on(network, instance) deployment_head{deployment=\"$deployment\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Block Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(deployment_head{deployment=\"$deployment\"}[5m])",
+          "legendFormat": "{{deployment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Blocks Per Sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(deployment_block_processing_duration_sum{deployment=\"$deployment\"}[5m]) / rate(deployment_block_processing_duration_count{deployment=\"$deployment\"}[5m])",
+          "legendFormat": "{{deployment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Block Processing Duration (sec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(deployment_transact_block_operations_duration_sum{deployment=\"$deployment\"}[5m])/rate(deployment_trigger_processing_duration_count{deployment=\"$deployment\"}[5m])",
+          "legendFormat": "{{deployment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transact Block Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 0,
+        "y": 11
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(deployment_sync_secs{deployment=\"$deployment\"}[5m])",
+          "legendFormat": "{{section}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Deployment Sync Sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "rate(eth_rpc_request_duration_count[5m])",
+          "legendFormat": "{{provider}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Eth Requests / Sec",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "QmUGTBpna7c9dwMeWwSfazu2bVV9UDGZSbdHxha3CCuzk4",
+          "value": "QmUGTBpna7c9dwMeWwSfazu2bVV9UDGZSbdHxha3CCuzk4"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(deployment)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "deployment",
+        "multi": false,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Graphnode Details",
+  "uid": "Gy0zjS-Vk",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/dashboards/graph-node-detail.yml
+++ b/docker/grafana/dashboards/graph-node-detail.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: Prometheus
+    folder: Graphnode
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards/graph-node-detail.json

--- a/docker/grafana/datasources/datasource.yml
+++ b/docker/grafana/datasources/datasource.yml
@@ -10,4 +10,3 @@ datasources:
       httpMethod: GET
       manageAlerts: true
       prometheusType: Prometheus
-      prometheusVersion: ">2.4.0"

--- a/docker/grafana/datasources/datasource.yml
+++ b/docker/grafana/datasources/datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    access: proxy
+    url: http://host.docker.internal:9090
+    jsonData:
+      httpMethod: GET
+      manageAlerts: true
+      prometheusType: Prometheus
+      prometheusVersion: ">2.4.0"

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 5s
+  external_labels:
+    monitor: 'codelab-monitor'
+
+scrape_configs:
+  - job_name: 'graph-node'
+    static_configs:
+      - targets: ['localhost:8040', 'host.docker.internal:8040', '0.0.0.0:8040']

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -1,0 +1,20 @@
+# Graphnode Optimization
+- Here we document the findingds of how to optimize graphnode
+
+
+## Supporting SQL
+
+- Get size of all namespaces in the database
+```
+SELECT schema_name,
+       pg_size_pretty(sum(table_size)::bigint),
+       (sum(table_size) / pg_database_size(current_database())) * 100
+FROM (
+  SELECT pg_catalog.pg_namespace.nspname as schema_name,
+         pg_relation_size(pg_catalog.pg_class.oid) as table_size
+  FROM   pg_catalog.pg_class
+     JOIN pg_catalog.pg_namespace ON relnamespace = pg_catalog.pg_namespace.oid
+) t
+GROUP BY schema_name
+ORDER BY schema_name;
+```

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -388,7 +388,7 @@ pub struct BlockStreamMetrics {
 impl BlockStreamMetrics {
     pub fn new(
         registry: Arc<dyn MetricsRegistry>,
-        deployment_id: String,
+        deployment: &DeploymentLocator,
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
@@ -397,11 +397,12 @@ impl BlockStreamMetrics {
             .new_deployment_gauge(
                 "deployment_reverted_blocks",
                 "Track the last reverted block for a subgraph deployment",
-                deployment_id.as_str(),
+                deployment.hash.as_str(),
             )
             .expect("Failed to create `deployment_reverted_blocks` gauge");
         let labels = labels! {
-            String::from("deployment") => deployment_id,
+            String::from("deployment") => deployment.hash.to_string(),
+            String::from("name") => deployment.name.clone().unwrap_or_default(),
             String::from("network") => network,
             String::from("shard") => shard
         };

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -388,7 +388,7 @@ pub struct BlockStreamMetrics {
 impl BlockStreamMetrics {
     pub fn new(
         registry: Arc<dyn MetricsRegistry>,
-        deployment_id: &DeploymentHash,
+        deployment_id: String,
         network: String,
         shard: String,
         stopwatch: StopwatchMetrics,
@@ -401,7 +401,7 @@ impl BlockStreamMetrics {
             )
             .expect("Failed to create `deployment_reverted_blocks` gauge");
         let labels = labels! {
-            String::from("deployment") => deployment_id.to_string(),
+            String::from("deployment") => deployment_id,
             String::from("network") => network,
             String::from("shard") => shard
         };

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -1,3 +1,4 @@
+use crate::components::store::DeploymentLocator;
 use crate::prelude::*;
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Mutex};
 use std::time::Instant;
@@ -43,7 +44,7 @@ impl CheapClone for StopwatchMetrics {}
 impl StopwatchMetrics {
     pub fn new(
         logger: Logger,
-        subgraph_name: String,
+        deployment: &DeploymentLocator,
         stage: &str,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -53,13 +54,13 @@ impl StopwatchMetrics {
                 .global_deployment_counter_vec(
                     "deployment_sync_secs",
                     "total time spent syncing",
-                    subgraph_name.as_str(),
+                    &deployment,
                     &["section", "stage"],
                 )
                 .unwrap_or_else(|_| {
                     panic!(
                         "failed to register subgraph_sync_total_secs prometheus counter for {}",
-                        subgraph_name
+                        &deployment.readable_name()
                     )
                 }),
             logger,

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -43,7 +43,7 @@ impl CheapClone for StopwatchMetrics {}
 impl StopwatchMetrics {
     pub fn new(
         logger: Logger,
-        subgraph_id: DeploymentHash,
+        subgraph_name: String,
         stage: &str,
         registry: Arc<dyn MetricsRegistry>,
     ) -> Self {
@@ -53,13 +53,13 @@ impl StopwatchMetrics {
                 .global_deployment_counter_vec(
                     "deployment_sync_secs",
                     "total time spent syncing",
-                    subgraph_id.as_str(),
+                    subgraph_name.as_str(),
                     &["section", "stage"],
                 )
                 .unwrap_or_else(|_| {
                     panic!(
                         "failed to register subgraph_sync_total_secs prometheus counter for {}",
-                        subgraph_id
+                        subgraph_name
                     )
                 }),
             logger,

--- a/graph/src/components/metrics/subgraph.rs
+++ b/graph/src/components/metrics/subgraph.rs
@@ -1,6 +1,7 @@
 use prometheus::Counter;
 
 use crate::blockchain::block_stream::BlockStreamMetrics;
+use crate::components::store::DeploymentLocator;
 use crate::prelude::{Gauge, Histogram, HostMetrics, MetricsRegistry};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -20,14 +21,14 @@ pub struct SubgraphInstanceMetrics {
 impl SubgraphInstanceMetrics {
     pub fn new(
         registry: Arc<dyn MetricsRegistry>,
-        subgraph_hash: &str,
+        deployment: &DeploymentLocator,
         stopwatch: StopwatchMetrics,
     ) -> Self {
         let block_trigger_count = registry
             .new_deployment_histogram(
                 "deployment_block_trigger_count",
                 "Measures the number of triggers in each block for a subgraph deployment",
-                subgraph_hash,
+                &deployment,
                 vec![1.0, 5.0, 10.0, 20.0, 50.0],
             )
             .expect("failed to create `deployment_block_trigger_count` histogram");
@@ -35,7 +36,7 @@ impl SubgraphInstanceMetrics {
             .new_deployment_histogram(
                 "deployment_trigger_processing_duration",
                 "Measures duration of trigger processing for a subgraph deployment",
-                subgraph_hash,
+                &deployment,
                 vec![0.01, 0.05, 0.1, 0.5, 1.5, 5.0, 10.0, 30.0, 120.0],
             )
             .expect("failed to create `deployment_trigger_processing_duration` histogram");
@@ -43,7 +44,7 @@ impl SubgraphInstanceMetrics {
             .new_deployment_histogram(
                 "deployment_block_processing_duration",
                 "Measures duration of block processing for a subgraph deployment",
-                subgraph_hash,
+                &deployment,
                 vec![0.05, 0.2, 0.7, 1.5, 4.0, 10.0, 60.0, 120.0, 240.0],
             )
             .expect("failed to create `deployment_block_processing_duration` histogram");
@@ -51,7 +52,7 @@ impl SubgraphInstanceMetrics {
             .new_deployment_histogram(
                 "deployment_transact_block_operations_duration",
                 "Measures duration of commiting all the entity operations in a block and updating the subgraph pointer",
-                subgraph_hash,
+                &deployment,
                 vec![0.01, 0.05, 0.1, 0.3, 0.7, 2.0],
             )
             .expect("failed to create `deployment_transact_block_operations_duration_{}");
@@ -60,7 +61,7 @@ impl SubgraphInstanceMetrics {
             .new_deployment_counter(
                 "firehose_connection_errors",
                 "Measures connections when trying to obtain a firehose connection",
-                subgraph_hash,
+                &deployment.hash,
             )
             .expect("failed to create firehose_connection_errors counter");
 

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -891,6 +891,7 @@ impl DeploymentId {
 pub struct DeploymentLocator {
     pub id: DeploymentId,
     pub hash: DeploymentHash,
+    pub name: Option<String>,
 }
 
 impl CheapClone for DeploymentLocator {}
@@ -907,8 +908,17 @@ impl slog::Value for DeploymentLocator {
 }
 
 impl DeploymentLocator {
-    pub fn new(id: DeploymentId, hash: DeploymentHash) -> Self {
-        Self { id, hash }
+    pub fn new(id: DeploymentId, hash: DeploymentHash, name: Option<String>) -> Self {
+        Self { id, hash, name }
+    }
+
+    pub fn readable_name(&self) -> String {
+        match self.name {
+            Some(ref subgraph_name) => {
+                format!("{} ({})", self.hash.to_string(), subgraph_name)
+            }
+            None => self.hash.to_string(),
+        }
     }
 }
 

--- a/graph/tests/entity_cache.rs
+++ b/graph/tests/entity_cache.rs
@@ -20,7 +20,7 @@ use graph::{
 lazy_static! {
     static ref SUBGRAPH_ID: DeploymentHash = DeploymentHash::new("entity_cache").unwrap();
     static ref DEPLOYMENT: DeploymentLocator =
-        DeploymentLocator::new(DeploymentId::new(-12), SUBGRAPH_ID.clone());
+        DeploymentLocator::new(DeploymentId::new(-12), SUBGRAPH_ID.clone(), None);
     static ref SCHEMA: Arc<Schema> = Arc::new(
         Schema::parse(
             "

--- a/mock/src/metrics_registry.rs
+++ b/mock/src/metrics_registry.rs
@@ -1,4 +1,5 @@
 use graph::components::metrics::{Collector, Counter, Gauge, Opts, PrometheusError};
+use graph::components::store::DeploymentLocator;
 use graph::prelude::MetricsRegistry as MetricsRegistryTrait;
 use graph::prometheus::{CounterVec, GaugeVec, HistogramOpts, HistogramVec};
 
@@ -55,10 +56,12 @@ impl MetricsRegistryTrait for MockMetricsRegistry {
         &self,
         name: &str,
         help: &str,
-        subgraph: &str,
+        deployment: &DeploymentLocator,
         variable_labels: &[&str],
     ) -> Result<CounterVec, PrometheusError> {
-        let opts = Opts::new(name, help).const_label("deployment", subgraph);
+        let opts = Opts::new(name, help)
+            .const_label("deployment", deployment.hash.to_string())
+            .const_label("name", deployment.name.clone().unwrap_or_default());
         let counters = CounterVec::new(opts, variable_labels)?;
         Ok(counters)
     }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1433,7 +1433,7 @@ mod tests {
                 details = { type = "firehose", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 10 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1471,7 +1471,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 101 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1509,7 +1509,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 10 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();
@@ -1547,7 +1547,7 @@ mod tests {
                 details = { type = "substreams", url = "http://localhost:9000" }
                 match = [
                   { name = "some_node_.*", limit = 101 },
-                  { name = "other_node_.*", limit = 0 } ] 
+                  { name = "other_node_.*", limit = 0 } ]
             "#,
         )
         .unwrap();

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -181,6 +181,7 @@ impl Deployment {
         DeploymentLocator::new(
             DeploymentId(self.id),
             DeploymentHash::new(self.deployment.clone()).unwrap(),
+            Some(self.name.clone()),
         )
     }
 

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -203,6 +203,20 @@ pub struct Opt {
     pub disable_block_ingestor: bool,
     #[clap(
         long,
+        value_name = "DISABLE_QUERY_SERVER",
+        env = "DISABLE_QUERY_SERVER",
+        help = "Disable GraphQL server (http & ws)"
+    )]
+    pub disable_query_server: bool,
+    #[clap(
+        long,
+        value_name = "DISABLE_METRICS_SERVER",
+        env = "DISABLE_METRICS_SERVER",
+        help = "Disable metrics server"
+    )]
+    pub disable_metrics_server: bool,
+    #[clap(
+        long,
         value_name = "STORE_CONNECTION_POOL_SIZE",
         default_value = "10",
         env = "STORE_CONNECTION_POOL_SIZE",

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -83,7 +83,7 @@ async fn test_valid_module_and_store_with_timeout(
     .await;
     let stopwatch_metrics = StopwatchMetrics::new(
         logger.clone(),
-        deployment.readable_name(),
+        &deployment,
         "test",
         metrics_registry.clone(),
     );

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -67,7 +67,7 @@ async fn test_valid_module_and_store_with_timeout(
     let store = STORE.clone();
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let deployment_id = DeploymentHash::new(&subgraph_id_with_api_version).unwrap();
-    let deployment = test_store::create_test_subgraph(
+    let deployment: DeploymentLocator = test_store::create_test_subgraph(
         &deployment_id,
         "type User @entity {
             id: ID!,
@@ -83,7 +83,7 @@ async fn test_valid_module_and_store_with_timeout(
     .await;
     let stopwatch_metrics = StopwatchMetrics::new(
         logger.clone(),
-        deployment_id.clone(),
+        deployment.readable_name(),
         "test",
         metrics_registry.clone(),
     );

--- a/store/postgres/migrations/2023-03-13_add_subgraph_name_to_deployment_schemas/up.sql
+++ b/store/postgres/migrations/2023-03-13_add_subgraph_name_to_deployment_schemas/up.sql
@@ -1,0 +1,2 @@
+alter table public.deployment_schemas
+  add subgraph_name text;

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -120,6 +120,7 @@ table! {
         id -> Integer,
         created_at -> Timestamptz,
         subgraph -> Text,
+        subgraph_name -> Nullable<Text>,
         name -> Text,
         shard -> Text,
         /// The subgraph layout scheme used for this subgraph
@@ -187,6 +188,7 @@ struct Schema {
     #[allow(dead_code)]
     pub created_at: PgTimestamp,
     pub subgraph: String,
+    pub subgraph_name: Option<String>,
     pub name: String,
     pub shard: String,
     version: i32,
@@ -327,6 +329,8 @@ pub struct Site {
     /// The subgraph deployment
     pub deployment: DeploymentHash,
     /// The name of the database shard
+    pub subgraph_name: Option<String>,
+    /// The name of the subgraph
     pub shard: Shard,
     /// The database namespace (schema) that holds the data for the deployment
     pub namespace: Namespace,
@@ -357,9 +361,11 @@ impl TryFrom<Schema> for Site {
         })?;
         let shard = Shard::new(schema.shard)?;
         let schema_version = DeploymentSchemaVersion::try_from(schema.version)?;
+        let subgraph_name = schema.subgraph_name;
         Ok(Self {
             id: schema.id,
             deployment,
+            subgraph_name,
             namespace,
             shard,
             network: schema.network,
@@ -372,7 +378,11 @@ impl TryFrom<Schema> for Site {
 
 impl From<&Site> for DeploymentLocator {
     fn from(site: &Site) -> Self {
-        DeploymentLocator::new(site.id.into(), site.deployment.clone())
+        DeploymentLocator::new(
+            site.id.into(),
+            site.deployment.clone(),
+            site.subgraph_name.clone(),
+        )
     }
 }
 
@@ -383,6 +393,7 @@ pub fn make_dummy_site(deployment: DeploymentHash, namespace: Namespace, network
     Site {
         id: DeploymentId(-7),
         deployment,
+        subgraph_name: None,
         shard: PRIMARY_SHARD.clone(),
         namespace,
         network,
@@ -668,6 +679,30 @@ mod queries {
                 .get_results(conn)
                 .map_err(Into::into)
     }
+
+    pub(super) fn fill_missing_subgraph_name(
+        conn: &PgConnection,
+        subgraph: &DeploymentHash,
+    ) -> Result<(), StoreError> {
+        let row = ds::table
+            .filter(ds::subgraph.eq(subgraph.to_string()))
+            .select(ds::all_columns)
+            .first::<Schema>(conn)
+            .optional()?;
+
+        if row.is_none() {
+            return Ok(());
+        }
+
+        let row = row.unwrap();
+        let names_and_versions = subgraphs_by_deployment_hash(conn, &row.subgraph)?;
+        let subgraph_name = &names_and_versions[0].0;
+
+        diesel::update(ds::table)
+            .set(ds::subgraph_name.eq(subgraph_name))
+            .execute(conn)
+            .map(|_| Ok(()))?
+    }
 }
 
 /// A wrapper for a database connection that provides access to functionality
@@ -743,7 +778,7 @@ impl<'a> Connection<'a> {
                 DeploymentHash::new(hash)
                     .map(|hash| {
                         EntityChange::for_assignment(
-                            DeploymentLocator::new(id.into(), hash),
+                            DeploymentLocator::new(id.into(), hash, None),
                             EntityChangeOperation::Removed,
                         )
                     })
@@ -1047,6 +1082,7 @@ impl<'a> Connection<'a> {
         &self,
         shard: Shard,
         deployment: DeploymentHash,
+        subgraph_name: Option<String>,
         network: String,
         schema_version: DeploymentSchemaVersion,
         active: bool,
@@ -1058,6 +1094,7 @@ impl<'a> Connection<'a> {
         let schemas: Vec<(DeploymentId, String)> = diesel::insert_into(ds::table)
             .values((
                 ds::subgraph.eq(deployment.as_str()),
+                ds::subgraph_name.eq(subgraph_name.clone()),
                 ds::shard.eq(shard.as_str()),
                 ds::version.eq(schema_version as i32),
                 ds::network.eq(network.as_str()),
@@ -1076,6 +1113,7 @@ impl<'a> Connection<'a> {
         Ok(Site {
             id,
             deployment,
+            subgraph_name,
             shard,
             namespace,
             network,
@@ -1090,6 +1128,7 @@ impl<'a> Connection<'a> {
         &self,
         shard: Shard,
         subgraph: &DeploymentHash,
+        subgraph_name: Option<String>,
         network: String,
         schema_version: DeploymentSchemaVersion,
     ) -> Result<Site, StoreError> {
@@ -1097,7 +1136,14 @@ impl<'a> Connection<'a> {
             return Ok(site);
         }
 
-        self.create_site(shard, subgraph.clone(), network, schema_version, true)
+        self.create_site(
+            shard,
+            subgraph.clone(),
+            subgraph_name,
+            network,
+            schema_version,
+            true,
+        )
     }
 
     pub fn assigned_node(&self, site: &Site) -> Result<Option<NodeId>, StoreError> {
@@ -1117,6 +1163,7 @@ impl<'a> Connection<'a> {
         self.create_site(
             shard,
             src.deployment.clone(),
+            src.subgraph_name.clone(),
             src.network.clone(),
             src.schema_version,
             false,
@@ -1780,5 +1827,9 @@ impl Mirror {
         shard: &Shard,
     ) -> Result<Option<Site>, StoreError> {
         self.read(|conn| queries::find_site_in_shard(conn, subgraph, shard))
+    }
+
+    pub fn fill_missing_subgraph_name(&self, subgraph: &DeploymentHash) -> Result<(), StoreError> {
+        self.read(|conn| queries::fill_missing_subgraph_name(conn, subgraph))
     }
 }

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -17,7 +17,7 @@ use graph::slog::info;
 use graph::util::bounded_queue::BoundedQueue;
 use graph::{
     cheap_clone::CheapClone,
-    components::store::{self, EntityType, WritableStore as WritableStoreTrait},
+    components::store::{self, DeploymentLocator, EntityType, WritableStore as WritableStoreTrait},
     data::subgraph::schema::SubgraphError,
     prelude::{
         BlockPtr, DeploymentHash, EntityModification, Error, Logger, StopwatchMetrics, StoreError,
@@ -628,12 +628,13 @@ impl Queue {
         // Use a separate instance of the `StopwatchMetrics` for background
         // work since that has its own call hierarchy, and using the
         // foreground metrics will lead to incorrect nesting of sections
-        let name = match store.site.subgraph_name.clone() {
-            Some(name) => format!("{} ({})", store.site.deployment.to_string(), name),
-            None => store.site.deployment.to_string(),
-        };
+        let deployment = DeploymentLocator::new(
+            store.site.id.into(),
+            store.site.deployment.clone(),
+            store.site.subgraph_name.clone(),
+        );
 
-        let stopwatch = StopwatchMetrics::new(logger.clone(), name, "writer", registry);
+        let stopwatch = StopwatchMetrics::new(logger.clone(), &deployment, "writer", registry);
 
         let queue = Self {
             store,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -628,12 +628,12 @@ impl Queue {
         // Use a separate instance of the `StopwatchMetrics` for background
         // work since that has its own call hierarchy, and using the
         // foreground metrics will lead to incorrect nesting of sections
-        let stopwatch = StopwatchMetrics::new(
-            logger.clone(),
-            store.site.deployment.clone(),
-            "writer",
-            registry,
-        );
+        let name = match store.site.subgraph_name.clone() {
+            Some(name) => format!("{} ({})", store.site.deployment.to_string(), name),
+            None => store.site.deployment.to_string(),
+        };
+
+        let stopwatch = StopwatchMetrics::new(logger.clone(), name, "writer", registry);
 
         let queue = Self {
             store,

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -24,7 +24,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use graph::{
-    components::store::{AttributeNames, EntityType},
+    components::store::{AttributeNames, DeploymentId, DeploymentLocator, EntityType},
     data::store::scalar::{BigDecimal, BigInt, Bytes},
 };
 use graph_store_postgres::{
@@ -193,9 +193,14 @@ lazy_static! {
     static ref SCALAR: EntityType = EntityType::from("Scalar");
     static ref NO_ENTITY: EntityType = EntityType::from("NoEntity");
     static ref NULLABLE_STRINGS: EntityType = EntityType::from("NullableStrings");
+    static ref DEPLOYMENT: DeploymentLocator = DeploymentLocator::new(
+        DeploymentId::new(1),
+        DeploymentHash::new("other-things").unwrap(),
+        None
+    );
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        THINGS_SUBGRAPH_ID.clone().to_string(),
+        &DEPLOYMENT,
         "test",
         Arc::new(MockMetricsRegistry::new()),
     );

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -195,7 +195,7 @@ lazy_static! {
     static ref NULLABLE_STRINGS: EntityType = EntityType::from("NullableStrings");
     static ref DEPLOYMENT: DeploymentLocator = DeploymentLocator::new(
         DeploymentId::new(1),
-        DeploymentHash::new("other-things").unwrap(),
+        DeploymentHash::new("otherthings").unwrap(),
         None
     );
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(

--- a/store/postgres/tests/relational.rs
+++ b/store/postgres/tests/relational.rs
@@ -195,7 +195,7 @@ lazy_static! {
     static ref NULLABLE_STRINGS: EntityType = EntityType::from("NullableStrings");
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        THINGS_SUBGRAPH_ID.clone(),
+        THINGS_SUBGRAPH_ID.clone().to_string(),
         "test",
         Arc::new(MockMetricsRegistry::new()),
     );

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -19,7 +19,7 @@ use graph::prelude::{
     Value, WindowAttribute, BLOCK_NUMBER_MAX,
 };
 use graph::{
-    components::store::EntityType,
+    components::store::{DeploymentId, DeploymentLocator, EntityType},
     data::store::scalar::{BigDecimal, BigInt},
 };
 use graph_store_postgres::{
@@ -74,9 +74,14 @@ lazy_static! {
     };
     static ref NAMESPACE: Namespace = Namespace::new("sgd0815".to_string()).unwrap();
     static ref THING: EntityType = EntityType::from("Thing");
+    static ref DEPLOYMENT: DeploymentLocator = DeploymentLocator::new(
+        DeploymentId::new(1),
+        DeploymentHash::new("other-things").unwrap(),
+        None
+    );
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        THINGS_SUBGRAPH_ID.clone().to_string(),
+        &DEPLOYMENT,
         "test",
         Arc::new(MockMetricsRegistry::new()),
     );

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -76,7 +76,7 @@ lazy_static! {
     static ref THING: EntityType = EntityType::from("Thing");
     static ref DEPLOYMENT: DeploymentLocator = DeploymentLocator::new(
         DeploymentId::new(1),
-        DeploymentHash::new("other-things").unwrap(),
+        DeploymentHash::new("otherthings").unwrap(),
         None
     );
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(

--- a/store/postgres/tests/relational_bytes.rs
+++ b/store/postgres/tests/relational_bytes.rs
@@ -76,7 +76,7 @@ lazy_static! {
     static ref THING: EntityType = EntityType::from("Thing");
     static ref MOCK_STOPWATCH: StopwatchMetrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        THINGS_SUBGRAPH_ID.clone(),
+        THINGS_SUBGRAPH_ID.clone().to_string(),
         "test",
         Arc::new(MockMetricsRegistry::new()),
     );

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1563,7 +1563,7 @@ fn handle_large_string_with_index() {
         let metrics_registry = Arc::new(MockMetricsRegistry::new());
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
-            deployment.readable_name(),
+            &deployment,
             "test",
             metrics_registry.clone(),
         );
@@ -1662,7 +1662,7 @@ fn handle_large_bytea_with_index() {
         let metrics_registry = Arc::new(MockMetricsRegistry::new());
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
-            deployment.readable_name(),
+            &deployment,
             "test",
             metrics_registry.clone(),
         );

--- a/store/postgres/tests/store.rs
+++ b/store/postgres/tests/store.rs
@@ -1563,7 +1563,7 @@ fn handle_large_string_with_index() {
         let metrics_registry = Arc::new(MockMetricsRegistry::new());
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
-            deployment.hash.clone(),
+            deployment.readable_name(),
             "test",
             metrics_registry.clone(),
         );
@@ -1662,7 +1662,7 @@ fn handle_large_bytea_with_index() {
         let metrics_registry = Arc::new(MockMetricsRegistry::new());
         let stopwatch_metrics = StopwatchMetrics::new(
             Logger::root(slog::Discard, o!()),
-            deployment.hash.clone(),
+            deployment.readable_name(),
             "test",
             metrics_registry.clone(),
         );

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -221,7 +221,7 @@ pub async fn transact_errors(
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        deployment.readable_name(),
+        deployment,
         "transact",
         metrics_registry.clone(),
     );
@@ -299,7 +299,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        deployment.readable_name(),
+        &deployment,
         "transact",
         metrics_registry.clone(),
     );

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -221,7 +221,7 @@ pub async fn transact_errors(
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        deployment.hash.clone(),
+        deployment.readable_name(),
         "transact",
         metrics_registry.clone(),
     );
@@ -299,7 +299,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     let metrics_registry = Arc::new(MockMetricsRegistry::new());
     let stopwatch_metrics = StopwatchMetrics::new(
         Logger::root(slog::Discard, o!()),
-        deployment.hash.clone(),
+        deployment.readable_name(),
         "transact",
         metrics_registry.clone(),
     );


### PR DESCRIPTION
# Graphnode v0.30.1

### Improve developer experience 
- Added pre-setup `Grafana` & `Prometheus` to docker-compose

### Add more flexibility when tuning Graphnode by providing 3 new Envars
- `DISABLE_BLOCK_INGESTOR` now when set to `true` will disable indexing functionality of Graphnode
- `DISABLE_QUERY_SERVER` now when set to `true` will disable GraphQL query server
- `DISABLE_METRICS_SERVER` now when set to `true` will disable prometheus metrics

### Improve Graphnode monitoring experience
- Provided `Subgraph Name` to every prometheus metrics. 

