### PR TITLE
Add force manual-revert

### DIFF
--- a/core/src/subgraph/context.rs
+++ b/core/src/subgraph/context.rs
@@ -35,7 +35,7 @@ where
     T: RuntimeHostBuilder<C>,
     C: Blockchain,
 {
-    instance: SubgraphInstance<C, T>,
+    pub instance: SubgraphInstance<C, T>,
     pub instances: SharedInstanceKeepAliveMap,
     pub filter: C::TriggerFilter,
     pub offchain_monitor: OffchainMonitor,

--- a/core/src/subgraph/context/instance.rs
+++ b/core/src/subgraph/context/instance.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use super::OffchainMonitor;
 
 pub struct SubgraphInstance<C: Blockchain, T: RuntimeHostBuilder<C>> {
-    subgraph_id: DeploymentHash,
+    pub subgraph_id: DeploymentHash,
     network: String,
     host_builder: T,
     templates: Arc<Vec<DataSourceTemplate<C>>>,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -670,8 +670,13 @@ where
     ) -> Result<Action, Error> {
         let action = match event {
             Some(Ok(BlockStreamEvent::ProcessBlock(block, cursor))) => {
-                self.handle_process_block(block, cursor, cancel_handle)
-                    .await?
+                let has_force_revert = self.force_manual_revert(cursor.clone()).await?;
+                if !has_force_revert {
+                    self.handle_process_block(block, cursor, cancel_handle)
+                        .await?
+                } else {
+                    Action::Restart
+                }
             }
             Some(Ok(BlockStreamEvent::Revert(revert_to_ptr, cursor))) => {
                 self.handle_revert(revert_to_ptr, cursor).await?

--- a/node/src/manager/commands/index.rs
+++ b/node/src/manager/commands/index.rs
@@ -90,11 +90,6 @@ pub async fn list(
         Ok(())
     }
 
-    fn footer(term: &mut Terminal) -> Result<(), anyhow::Error> {
-        writeln!(term, "  (a): account-like flag set")?;
-        Ok(())
-    }
-
     fn print_index(term: &mut Terminal, index: &CreateIndex) -> CmdResult {
         use CreateIndex::*;
 


### PR DESCRIPTION
Allow force manual revert using ENV

```
MANUAL_REVERT={subgraph_hash},{block_number},{block_hash}
```

When set, graphnode will attempt to revert the specified subgraph to the spcified block number. There are a few notes & warnings:
- This envar when set will affect the process once, after revert, the process will clear the Envar then keep running forward
## **WARNING: block hash must match the block number's hash, otherwise it will corrupt the subgraph.**
## **WARNING: if the process restarts, it will check the Envar again and attempt the revert - therefore, after revert success, immediately remove the envar!**
